### PR TITLE
Fix getCaretYPosition and stop selectionchange infinite loop on Android SDK > 27

### DIFF
--- a/src/editor.html
+++ b/src/editor.html
@@ -778,6 +778,30 @@
 				return multi_parser.output.join('');
 			}
 
+			function getMirrorInfo(element) {
+				if (element.mirrorInfo) {
+					return element.mirrorInfo;
+				}
+
+				var div = document.createElement('div');
+				var style = div.style;
+				var hidden = 'hidden';
+				var focusOut = 'focusout';
+				style.whiteSpace = 'pre-wrap';
+				style.wordWrap = 'break-word';
+				style.position = 'absolute';
+				style.visibility = hidden;
+				style.overflow = hidden;
+				document.body.appendChild(div);
+				element.mirrorInfo = { div: div, span: document.createElement('span') };
+				element.addEventListener(focusOut, function cleanup() {
+					delete element.mirrorInfo;
+					document.body.removeChild(div);
+					element.removeEventListener(focusOut, cleanup);
+				});
+				return element.mirrorInfo;
+			}
+
 			/*!
 			 *
 			 * ZSSRichTextEditor v0.5.2
@@ -1025,16 +1049,24 @@
 			}
 
 			zss_editor.getCaretYPosition = function() {
-				var sel = window.getSelection();
-				// Next line is comented to prevent deselecting selection. It looks like work but if there are any issues will appear then uconmment it as well as code above.
-				//sel.collapseToStart();
-				var range = sel.getRangeAt(0);
-				var span = document.createElement('span');// something happening here preventing selection of elements
-				range.collapse(false);
-				range.insertNode(span);
-				var topPosition = span.offsetTop;
-				span.parentNode.removeChild(span);
-				return topPosition;
+				var selection = window.getSelection();
+				var range = selection.getRangeAt(0);
+				var container = range.endContainer;
+				var selectedNode = container.nodeType === 3 ? container.parentNode : container;
+				var position = selectedNode.selectionEnd;
+				var _a = getMirrorInfo(selectedNode);
+				var div = _a.div;
+				var span = _a.span;
+				var content = selectedNode.textContent.substring(0, position);
+
+				div.textContent = content;
+				span.textContent = (selectedNode.textContent.substring(position)) || '.';
+				div.appendChild(span);
+
+				var rect = selectedNode.getBoundingClientRect();
+				var top = span.offsetTop - selectedNode.scrollTop + rect.top;
+
+				return top;
 			}
 
 			zss_editor.calculateEditorHeightWithCaretPosition = function() {


### PR DESCRIPTION
Resolving:
https://github.com/wix/react-native-zss-rich-text-editor/issues/39
https://github.com/wix/react-native-zss-rich-text-editor/issues/97

Merging this PR: https://github.com/wix/react-native-zss-rich-text-editor/pull/132